### PR TITLE
Fixed the interaction of piston, slime and honey blocks.

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockObserver.java
+++ b/src/main/java/cn/nukkit/block/BlockObserver.java
@@ -117,7 +117,7 @@ public class BlockObserver extends BlockSolidMeta implements Faceable {
 
     @Override
     public int getWeakPower(BlockFace blockFace) {
-        return this.getStrongPower(blockFace);
+        return this.isPowered() && blockFace == this.getBlockFace() ? 15 : 0;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockPistonBase.java
+++ b/src/main/java/cn/nukkit/block/BlockPistonBase.java
@@ -9,6 +9,7 @@ import cn.nukkit.blockentity.impl.BlockEntityPistonArm;
 import cn.nukkit.event.block.BlockPistonEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
+import cn.nukkit.level.GameRule;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.Sound;
 import cn.nukkit.level.vibration.VanillaVibrationTypes;
@@ -131,9 +132,29 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
 
         BlockEntity blockEntity = this.level.getBlockEntity(this);
         if (blockEntity instanceof BlockEntityPistonArm arm) {
+            if (arm.state % 2 != 0) {
+                return type;
+            }
             boolean powered = this.isPowered();
-
-            if (arm.state % 2 == 0 && arm.powered != powered && this.checkState(powered)) {
+            boolean extended = this.isExtended();
+            if (powered != extended) {
+                boolean canChange = arm.powered != powered;
+                if (this.checkState(powered)) {
+                    if (canChange) {
+                        arm.powered = powered;
+                        if (arm.chunk != null) {
+                            arm.chunk.setChanged();
+                        }
+                    }
+                } else {
+                    // blocked due to limit or obstacle - retry next tick (vanilla MCBE behavior)
+                    // optimization: only schedule while mismatch persists
+                    this.level.scheduleUpdate(this, 1);
+                    // keep arm.powered in sync if needed for redstone? don't update on failure
+                }
+                return type;
+            }
+            if (arm.powered != powered) {
                 arm.powered = powered;
                 if (arm.chunk != null) {
                     arm.chunk.setChanged();
@@ -334,6 +355,40 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
             }
         }
 
+        private static boolean isSticky(Block block) {
+            int id = block.getId();
+            return id == SLIME_BLOCK || id == HONEY_BLOCK;
+        }
+
+        private static boolean canStick(Block a, Block b) {
+            int idA = a.getId();
+            int idB = b.getId();
+            if ((idA == HONEY_BLOCK && idB == SLIME_BLOCK) || (idA == SLIME_BLOCK && idB == HONEY_BLOCK)) {
+                return false;
+            }
+            return isSticky(a) || isSticky(b);
+        }
+
+        private int getPushLimit() {
+            Level lvl = BlockPistonBase.this.level;
+            if (lvl == null) {
+                try {
+                    lvl = BlockPistonBase.this.getLevel();
+                } catch (Exception ignored) {}
+            }
+            if (lvl != null && lvl.gameRules != null) {
+                try {
+                    if (lvl.gameRules.hasRule(GameRule.PISTON_PUSH_LIMIT)) {
+                        int v = lvl.gameRules.getInteger(GameRule.PISTON_PUSH_LIMIT);
+                        if (v == -1) return Integer.MAX_VALUE;
+                        if (v < 0) return 0;
+                        return v;
+                    }
+                } catch (Exception ignored) {}
+            }
+            return 12;
+        }
+
         public boolean canMove() {
             if (!sticky && !extending) {
                 return true;
@@ -342,6 +397,10 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
             this.toMove.clear();
             this.toDestroy.clear();
             Block block = this.blockToMove;
+
+            if (block == null) {
+                return true;
+            }
 
             if (!canPush(block, this.moveDirection, true, extending)) {
                 return false;
@@ -358,9 +417,9 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
                 return false;
             }
 
-            for (Block b : new ArrayList<>(this.toMove)) {
-                int blockId = b.getId();
-                if ((blockId == SLIME_BLOCK) && !this.addBranchingBlocks(b)) {
+            for (int i = 0; i < this.toMove.size(); i++) {
+                Block b = this.toMove.get(i);
+                if (isSticky(b) && !this.addBranchingBlocks(b)) {
                     return false;
                 }
             }
@@ -386,7 +445,8 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
                 return true;
             }
 
-            if (this.toMove.size() >= 12) {
+            int pushLimit = getPushLimit();
+            if (this.toMove.size() >= pushLimit) {
                 return false;
             }
 
@@ -394,24 +454,22 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
 
             int count = 1;
             List<Block> sticked = new ArrayList<>();
+            Block cur = block;
 
-            while (block.getId() == SLIME_BLOCK) {
-                block = origin.getSide(this.moveDirection.getOpposite(), count);
-
-                if (block.getId() == AIR || !canPush(block, this.moveDirection, false, extending) || block.equals(this.pistonPos)) {
+            while (isSticky(cur)) {
+                Block next = origin.getSide(this.moveDirection.getOpposite(), count);
+                if (next.getId() == AIR || !canStick(cur, next) || !canPush(next, this.moveDirection, false, extending) || next.equals(this.pistonPos)) {
                     break;
                 }
-
-                if (block.breaksWhenMoved() && block.sticksToPiston()) {
-                    this.toDestroy.add(block);
+                if (next.breaksWhenMoved() && next.sticksToPiston()) {
+                    this.toDestroy.add(next);
                     break;
                 }
-
-                if (++count + this.toMove.size() > 12) {
+                if (++count + this.toMove.size() > pushLimit) {
                     return false;
                 }
-
-                sticked.add(block);
+                sticked.add(next);
+                cur = next;
             }
 
             int stickedCount = sticked.size();
@@ -420,6 +478,7 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
                 this.toMove.addAll(Lists.reverse(sticked));
             }
 
+            int blocksAdded = 1 + stickedCount;
             int step = 1;
 
             while (true) {
@@ -427,12 +486,12 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
                 int index = this.toMove.indexOf(nextBlock);
 
                 if (index > -1) {
-                    this.reorderListAtCollision(stickedCount, index);
+                    this.reorderListAtCollision(blocksAdded, index);
 
-                    for (int i = 0; i <= index + stickedCount; ++i) {
+                    for (int i = 0; i <= index + blocksAdded; ++i) {
                         Block b = this.toMove.get(i);
-
-                        if (b.getId() == SLIME_BLOCK && !this.addBranchingBlocks(b)) {
+                        if (b == null) break;
+                        if (isSticky(b) && !this.addBranchingBlocks(b)) {
                             return false;
                         }
                     }
@@ -440,7 +499,7 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
                     return true;
                 }
 
-                if (nextBlock.getId() == AIR || nextBlock.equals(armPos)) {
+                if (nextBlock.getId() == AIR || (armPos != null && nextBlock.equals(armPos))) {
                     return true;
                 }
 
@@ -453,11 +512,12 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
                     return true;
                 }
 
-                if (this.toMove.size() >= 12) {
+                if (this.toMove.size() >= getPushLimit()) {
                     return false;
                 }
 
                 this.toMove.add(nextBlock);
+                ++blocksAdded;
                 ++stickedCount;
                 ++step;
             }
@@ -475,11 +535,13 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
 
         private boolean addBranchingBlocks(Block block) {
             for (BlockFace face : BlockFace.values()) {
-                if (face.getAxis() != this.moveDirection.getAxis() && !this.addBlockLine(block.getSide(face), face)) {
-                    return false;
+                if (face.getAxis() != this.moveDirection.getAxis()) {
+                    Block neighbor = block.getSide(face);
+                    if (canStick(neighbor, block) && !this.addBlockLine(neighbor, face)) {
+                        return false;
+                    }
                 }
             }
-
             return true;
         }
 

--- a/src/main/java/cn/nukkit/blockentity/impl/BlockEntityPistonArm.java
+++ b/src/main/java/cn/nukkit/blockentity/impl/BlockEntityPistonArm.java
@@ -13,6 +13,7 @@ import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.BlockVector3;
 import cn.nukkit.math.SimpleAxisAlignedBB;
+import cn.nukkit.math.Vector3;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.IntTag;
 import cn.nukkit.nbt.tag.ListTag;
@@ -189,6 +190,24 @@ public class BlockEntityPistonArm extends BlockEntitySpawnable {
             }
 
             this.level.updateAroundObserver(this);
+            // notify observers around all moved blocks (old and new positions) - needed for flying machines
+            for (BlockVector3 pos : this.attachedBlocks) {
+                BlockVector3 newPos = pos.getSide(pushDir);
+                this.level.updateAroundObserver(newPos.asVector3());
+                this.level.updateAroundObserver(pos.asVector3());
+                // also updateAround to ensure onNeighborChange via normal queue
+                this.level.updateAround(newPos.asVector3());
+                this.level.updateAround(pos.asVector3());
+            }
+            if (extending) {
+                Vector3 headPos = this.add(facing.getXOffset(), facing.getYOffset(), facing.getZOffset());
+                this.level.updateAroundObserver(headPos);
+                this.level.updateAround(headPos);
+            } else {
+                Vector3 headPos = this.add(facing.getXOffset(), facing.getYOffset(), facing.getZOffset());
+                this.level.updateAroundObserver(headPos);
+                this.level.updateAround(headPos);
+            }
 
             this.level.scheduleUpdate(this.getLevelBlock(), 1);
             this.attachedBlocks.clear();

--- a/src/main/java/cn/nukkit/command/defaults/GameruleCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/GameruleCommand.java
@@ -1,5 +1,6 @@
 package cn.nukkit.command.defaults;
 
+import cn.nukkit.Server;
 import cn.nukkit.command.CommandSender;
 import cn.nukkit.command.data.CommandEnum;
 import cn.nukkit.command.data.CommandParamType;
@@ -8,6 +9,7 @@ import cn.nukkit.command.tree.ParamList;
 import cn.nukkit.command.utils.CommandLogger;
 import cn.nukkit.level.GameRule;
 import cn.nukkit.level.GameRules;
+import cn.nukkit.level.Level;
 
 import java.util.*;
 
@@ -62,7 +64,17 @@ public class GameruleCommand extends VanillaCommand {
 
     @Override
     public int execute(CommandSender sender, String commandLabel, Map.Entry<String, ParamList> result, CommandLogger log) {
-        GameRules rules = sender.getPosition().level.getGameRules();
+        GameRules rules;
+        try {
+            var pos = sender.getPosition();
+            if (pos != null && pos.level != null) {
+                rules = pos.level.getGameRules();
+            } else {
+                rules = Server.getInstance().getDefaultLevel().getGameRules();
+            }
+        } catch (Exception e) {
+            rules = GameRules.getDefault();
+        }
         var list = result.getValue();
         String ruleStr = list.getResult(0);
         if (result.getKey().equals("default")) {
@@ -87,26 +99,116 @@ public class GameruleCommand extends VanillaCommand {
             log.addSyntaxErrors(0).output();
             return 0;
         }
+        GameRule gameRule = optionalRule.get();
+        // helper to get sender level for non-piston rules
+        Level senderLevel = null;
+        try {
+            var pos = sender.getPosition();
+            if (pos != null && pos.level != null) senderLevel = pos.level;
+            else senderLevel = Server.getInstance().getDefaultLevel();
+        } catch (Exception ignored) {
+            senderLevel = Server.getInstance().getDefaultLevel();
+        }
         switch (result.getKey()) {
             case "boolGameRules" -> {
                 boolean value = list.getResult(1);
-                rules.setGameRule(optionalRule.get(), value);
+                if (senderLevel != null) {
+                    senderLevel.getGameRules().setGameRule(gameRule, value);
+                    senderLevel.getProvider().setGameRules(senderLevel.getGameRules());
+                }
             }
             case "intGameRules" -> {
-                int value = list.getResult(1);
-                rules.setGameRule(optionalRule.get(), value);
+                int raw = list.getResult(1);
+                int value = raw;
+                if (gameRule == GameRule.PISTON_PUSH_LIMIT) {
+                    if (raw == -1) value = Integer.MAX_VALUE;
+                    // piston limit must affect all 3 dimensions
+                    applyToAllLevels(gameRule, value);
+                } else {
+                    if (senderLevel != null) {
+                        senderLevel.getGameRules().setGameRule(gameRule, value);
+                        senderLevel.getProvider().setGameRules(senderLevel.getGameRules());
+                    }
+                }
             }
             case "floatGameRules" -> {
                 float value = list.getResult(1);
-                rules.setGameRule(optionalRule.get(), value);
+                if (senderLevel != null) {
+                    senderLevel.getGameRules().setGameRule(gameRule, value);
+                    senderLevel.getProvider().setGameRules(senderLevel.getGameRules());
+                }
             }
             case "unknownGameRules" -> {
                 String value = list.getResult(1);
-                rules.setGameRules(optionalRule.get(), value);
+                if (senderLevel != null) {
+                    senderLevel.getGameRules().setGameRules(gameRule, value);
+                    senderLevel.getProvider().setGameRules(senderLevel.getGameRules());
+                }
             }
         }
-        var str = list.getResult(1);
-        log.addSuccess("commands.gamerule.success", optionalRule.get().getName().toLowerCase(Locale.ROOT), str.toString()).output();
+        Object displayObj = list.getResult(1);
+        String display = displayObj == null ? "" : displayObj.toString();
+        // for pistonPushLimit show clamped value (-1 -> MAX)
+        if (gameRule == GameRule.PISTON_PUSH_LIMIT && result.getKey().equals("intGameRules")) {
+            int raw = list.getResult(1);
+            if (raw == -1) display = String.valueOf(Integer.MAX_VALUE);
+        }
+        log.addSuccess("commands.gamerule.success", gameRule.getName().toLowerCase(Locale.ROOT), display).output();
         return 1;
+    }
+
+    private void applyToAllLevels(GameRule rule, boolean value) {
+        for (Level level : Server.getInstance().getLevels().values()) {
+            try {
+                level.getGameRules().setGameRule(rule, value);
+                level.getProvider().setGameRules(level.getGameRules());
+            } catch (Exception ignored) {}
+        }
+    }
+
+    private void applyToAllLevels(GameRule rule, int value) {
+        for (Level level : Server.getInstance().getLevels().values()) {
+            try {
+                level.getGameRules().setGameRule(rule, value);
+                level.getProvider().setGameRules(level.getGameRules());
+                // immediate persistence to level.dat int tag
+                try { level.getProvider().saveLevelData(); } catch (Exception ignored) {}
+            } catch (Exception ignored) {}
+        }
+        if (rule == GameRule.PISTON_PUSH_LIMIT) {
+            // re-check all loaded pistons immediately - covers structures that were blocked by limit or obstacle
+            for (Level level : Server.getInstance().getLevels().values()) {
+                try {
+                    for (cn.nukkit.blockentity.BlockEntity be : new java.util.ArrayList<>(level.getBlockEntities().values())) {
+                        if (be instanceof cn.nukkit.blockentity.impl.BlockEntityPistonArm) {
+                            try {
+                                cn.nukkit.block.Block b = level.getBlock(be.getFloorX(), be.getFloorY(), be.getFloorZ());
+                                if (b instanceof cn.nukkit.block.BlockPistonBase) {
+                                    level.scheduleUpdate(b, 1);
+                                }
+                            } catch (Exception ignored) {}
+                        }
+                    }
+                } catch (Exception ignored) {}
+            }
+        }
+    }
+
+    private void applyToAllLevels(GameRule rule, float value) {
+        for (Level level : Server.getInstance().getLevels().values()) {
+            try {
+                level.getGameRules().setGameRule(rule, value);
+                level.getProvider().setGameRules(level.getGameRules());
+            } catch (Exception ignored) {}
+        }
+    }
+
+    private void applyToAllLevelsString(GameRule rule, String value) {
+        for (Level level : Server.getInstance().getLevels().values()) {
+            try {
+                level.getGameRules().setGameRules(rule, value);
+                level.getProvider().setGameRules(level.getGameRules());
+            } catch (Exception ignored) {}
+        }
     }
 }

--- a/src/main/java/cn/nukkit/command/tree/node/IntNode.java
+++ b/src/main/java/cn/nukkit/command/tree/node/IntNode.java
@@ -11,7 +11,15 @@ public class IntNode extends ParamNode<Integer> {
         try {
             this.value = Integer.parseInt(arg);
         } catch (NumberFormatException e) {
-            this.error();
+            // allow values beyond int range and clamp to int limits (for pistonPushLimit)
+            try {
+                long l = Long.parseLong(arg.trim());
+                if (l > Integer.MAX_VALUE) this.value = Integer.MAX_VALUE;
+                else if (l < Integer.MIN_VALUE) this.value = Integer.MIN_VALUE;
+                else this.value = (int) l;
+            } catch (NumberFormatException e2) {
+                this.error();
+            }
         }
     }
 

--- a/src/main/java/cn/nukkit/level/GameRule.java
+++ b/src/main/java/cn/nukkit/level/GameRule.java
@@ -42,7 +42,8 @@ public enum GameRule {
     RESPAWN_BLOCKS_EXPLODE("respawnBlocksExplode"),
     DO_LIMITED_CRAFTING("doLimitedCrafting"),
     SHOW_RECIPE_MESSAGE("showRecipeMessages"),
-    PROJECTILES_CAN_BREAK_BLOCKS("projectilesCanBreakBlocks");
+    PROJECTILES_CAN_BREAK_BLOCKS("projectilesCanBreakBlocks"),
+    PISTON_PUSH_LIMIT("pistonPushLimit");
 
     private final String name;
     private final String bedrockName;

--- a/src/main/java/cn/nukkit/level/GameRules.java
+++ b/src/main/java/cn/nukkit/level/GameRules.java
@@ -62,6 +62,7 @@ public class GameRules {
         gameRules.gameRules.put(DO_LIMITED_CRAFTING, new Value<>(Type.BOOLEAN, false, 618));
         gameRules.gameRules.put(SHOW_RECIPE_MESSAGE, new Value<>(Type.BOOLEAN, true, ProtocolInfo.v1_20_50));
         gameRules.gameRules.put(PROJECTILES_CAN_BREAK_BLOCKS, new Value<>(Type.BOOLEAN, true, ProtocolInfo.v1_20_50));
+        gameRules.gameRules.put(PISTON_PUSH_LIMIT, new Value<>(Type.INTEGER, 12));
 
         return gameRules;
     }


### PR DESCRIPTION
Experimental fix (using AI) of the behavior of pistons and blocks of slime and honey.
1) Now, when the slime structures move with a piston, they do not burst as in the picture: <img width="1185" height="551" alt="image" src="https://github.com/user-attachments/assets/78634503-9634-474d-a079-30430498782e" /> but move correctly as in the original game.

2) The slime blocks no longer stick to the honey blocks as in the original game.

3) If the powered piston tried to push forward, but an obstacle (for example, obsidian) prevented it, then after removing the obstacle, it will move this block (as in the original game), rather than standing still and waiting until the signal is turned off and on to update the piston so that it moves.

4) An attempt to correct the behavior of observers (no signal is given when is moved by the piston) - has not yet been completely corrected, further correction is needed.

A human check is required to ensure that this is good code or not and will cause server performance drawdowns. I did this just for the sake of experiment and personal use.